### PR TITLE
Removing usage of CustomData

### DIFF
--- a/Filing_Engine/Convert/ToFiling/FSDirectory.cs
+++ b/Filing_Engine/Convert/ToFiling/FSDirectory.cs
@@ -52,12 +52,6 @@ namespace BH.Engine.Adapters.Filing
             bd.IsReadOnly = di.Attributes.HasFlag(FileAttributes.ReadOnly);
             bd.Attributes = di.Attributes;
             bd.CreationTimeUtc = di.CreationTimeUtc;
-            bd.CustomData["CreationTime"] = di.CreationTime;
-            bd.CustomData["CreationTimeUtc"] = di.CreationTimeUtc;
-            bd.CustomData["LastAccessTime"] = di.LastAccessTime;
-            bd.CustomData["LastAccessTimeUtc"] = di.LastAccessTimeUtc;
-            bd.CustomData["LastWriteTime"] = di.LastWriteTime;
-            bd.CustomData["LastWriteTimeUtc"] = di.LastWriteTimeUtc;
             bd.ModifiedTimeUtc = di.LastWriteTimeUtc;
 
             return bd;

--- a/Filing_Engine/Convert/ToFiling/FSFile.cs
+++ b/Filing_Engine/Convert/ToFiling/FSFile.cs
@@ -53,12 +53,6 @@ namespace BH.Engine.Adapters.Filing
             bf.Size = (int)(fi.Length & 0xFFFFFFFF);
             bf.Attributes = fi.Attributes;
             bf.CreationTimeUtc = fi.CreationTimeUtc;
-            bf.CustomData["CreationTime"] = fi.CreationTime;
-            bf.CustomData["CreationTimeUtc"] = fi.CreationTimeUtc;
-            bf.CustomData["LastAccessTime"] = fi.LastAccessTime;
-            bf.CustomData["LastAccessTimeUtc"] = fi.LastAccessTimeUtc;
-            bf.CustomData["LastWriteTime"] = fi.LastWriteTime;
-            bf.CustomData["LastWriteTimeUtc"] = fi.LastWriteTimeUtc;
             bf.ModifiedTimeUtc = fi.LastWriteTimeUtc;
 
             return bf;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/Filing_Toolkit/issues/82

<!-- Add short description of what has been fixed -->

As explained in https://github.com/BHoM/Filing_Toolkit/issues/82#issuecomment-718738558,
ReadFileContent.cs has to read CustomData to check whether there is relevant information there to be Read, so it has to stay.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->